### PR TITLE
fix: add support for IAM-gated DNS access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+
+.idea/

--- a/tools/helm-test/includes/cluster/gke.sh
+++ b/tools/helm-test/includes/cluster/gke.sh
@@ -30,6 +30,18 @@ createGKECluster() {
     echo "${createClusterCommand[@]}"
     "${createClusterCommand[@]}"
   fi
+
+  # A private-endpoint cluster's auto-written kubeconfig uses the unreachable private IP.
+  # When DNS access is enabled, repoint kubeconfig at the IAM-gated DNS endpoint so
+  # kubectl/helm connect via IAM (no public endpoint, no IP allow-listing).
+  if yq eval -r -o=json '.cluster.args | join(" ")' "${testPlan}" | grep -q -- "--enable-dns-access"; then
+    getCredsCommand=(gcloud container clusters get-credentials "${clusterName}" --dns-endpoint)
+    [ -n "${location}" ] && getCredsCommand+=(--location "${location}")
+    [ -n "${region}" ] && getCredsCommand+=(--region "${region}")
+    [ -n "${zone}" ] && getCredsCommand+=(--zone "${zone}")
+    echo "${getCredsCommand[@]}"
+    "${getCredsCommand[@]}"
+  fi
 }
 
 createGKEAutopilotCluster() {
@@ -61,6 +73,18 @@ createGKEAutopilotCluster() {
     createClusterCommand+=("${args[@]}")
     echo "${createClusterCommand[@]}"
     "${createClusterCommand[@]}"
+  fi
+
+  # A private-endpoint cluster's auto-written kubeconfig uses the unreachable private IP.
+  # When DNS access is enabled, repoint kubeconfig at the IAM-gated DNS endpoint so
+  # kubectl/helm connect via IAM (no public endpoint, no IP allow-listing).
+  if yq eval -r -o=json '.cluster.args | join(" ")' "${testPlan}" | grep -q -- "--enable-dns-access"; then
+    getCredsCommand=(gcloud container clusters get-credentials "${clusterName}" --dns-endpoint)
+    [ -n "${location}" ] && getCredsCommand+=(--location "${location}")
+    [ -n "${region}" ] && getCredsCommand+=(--region "${region}")
+    [ -n "${zone}" ] && getCredsCommand+=(--zone "${zone}")
+    echo "${getCredsCommand[@]}"
+    "${getCredsCommand[@]}"
   fi
 }
 

--- a/tools/helm-test/includes/cluster/gke.sh
+++ b/tools/helm-test/includes/cluster/gke.sh
@@ -31,9 +31,8 @@ createGKECluster() {
     "${createClusterCommand[@]}"
   fi
 
-  # A private-endpoint cluster's auto-written kubeconfig uses the unreachable private IP.
   # When DNS access is enabled, repoint kubeconfig at the IAM-gated DNS endpoint so
-  # kubectl/helm connect via IAM (no public endpoint, no IP allow-listing).
+  # kubectl/helm connect via IAM instead of depending on a public endpoint or IP allow-listing.
   if yq eval -r -o=json '.cluster.args | join(" ")' "${testPlan}" | grep -q -- "--enable-dns-access"; then
     getCredsCommand=(gcloud container clusters get-credentials "${clusterName}" --dns-endpoint)
     [ -n "${location}" ] && getCredsCommand+=(--location "${location}")
@@ -75,9 +74,8 @@ createGKEAutopilotCluster() {
     "${createClusterCommand[@]}"
   fi
 
-  # A private-endpoint cluster's auto-written kubeconfig uses the unreachable private IP.
   # When DNS access is enabled, repoint kubeconfig at the IAM-gated DNS endpoint so
-  # kubectl/helm connect via IAM (no public endpoint, no IP allow-listing).
+  # kubectl/helm connect via IAM instead of depending on a public endpoint or IP allow-listing.
   if yq eval -r -o=json '.cluster.args | join(" ")' "${testPlan}" | grep -q -- "--enable-dns-access"; then
     getCredsCommand=(gcloud container clusters get-credentials "${clusterName}" --dns-endpoint)
     [ -n "${location}" ] && getCredsCommand+=(--location "${location}")


### PR DESCRIPTION
With our GKE cluster's restricting external IP access we need to rely on dns access to interact with the cluster via kubectl/helm. This command configures the kubeconfig to use the dns entry. 