### PR TITLE
feat: add timeout configuration

### DIFF
--- a/tools/helm-test/README.md
+++ b/tools/helm-test/README.md
@@ -29,14 +29,6 @@ run-tests
 delete-cluster
 ```
 
-### Environment variables
-
-| Variable            | Description                                                | Default |
-|---------------------|------------------------------------------------------------|---------|
-| `CREATE_CLUSTER`    | Create the cluster before testing.                         | `true`  |
-| `DELETE_CLUSTER`    | Delete the cluster after testing.                          | `false` |
-| `HELM_TEST_TIMEOUT` | Timeout passed to `helm test` for each test (e.g. `15m`).  | `5m`    |
-
 ## Test Plans
 
 The `test-plan.yaml` file defines the test plan for the Helm chart. It includes the following sections:

--- a/tools/helm-test/README.md
+++ b/tools/helm-test/README.md
@@ -29,6 +29,14 @@ run-tests
 delete-cluster
 ```
 
+### Environment variables
+
+| Variable            | Description                                                | Default |
+|---------------------|------------------------------------------------------------|---------|
+| `CREATE_CLUSTER`    | Create the cluster before testing.                         | `true`  |
+| `DELETE_CLUSTER`    | Delete the cluster after testing.                          | `false` |
+| `HELM_TEST_TIMEOUT` | Timeout passed to `helm test` for each test (e.g. `15m`).  | `5m`    |
+
 ## Test Plans
 
 The `test-plan.yaml` file defines the test plan for the Helm chart. It includes the following sections:

--- a/tools/helm-test/includes/cluster/common.sh
+++ b/tools/helm-test/includes/cluster/common.sh
@@ -34,3 +34,10 @@ getRandomNumber() {
   fi
   echo "${randomNumber}"
 }
+
+redactSecrets() {
+  local keys='(password|passwd|pwd|token|secret|api[_-]?key|apikey|access[_-]?key|secret[_-]?key|client[_-]?secret|credential|bearer)'
+  sed -E \
+    -e "s/(${keys}[\"']?[[:space:]]*[:=][[:space:]]*)([\"'])[^\"']*\3/\1\3[REDACTED]\3/gI" \
+    -e "s/(${keys}[\"']?[[:space:]]*[:=][[:space:]]*)[^[:space:],;\"']+/\1[REDACTED]/gI"
+}

--- a/tools/helm-test/includes/cluster/openshift.sh
+++ b/tools/helm-test/includes/cluster/openshift.sh
@@ -26,7 +26,7 @@ createOpenShiftCluster() {
     fi
 
     echo "${createClusterCommand[@]}"
-    "${createClusterCommand[@]}"
+    "${createClusterCommand[@]}" 2>&1 | redactSecrets
 
   fi
   ln -sfn "${clusterInstallerFilesDir}/auth/kubeconfig" "${testDir}/kubeconfig.yaml"

--- a/tools/helm-test/run-tests
+++ b/tools/helm-test/run-tests
@@ -35,11 +35,12 @@ fi
 
 # Start of script
 echo; echo "### Running tests"
+helmTestTimeout="${HELM_TEST_TIMEOUT:-5m}"
 testCount=$(yq eval '.tests | length - 1' "${testPlan}")
 if [ "${testCount}" -ge 0 ]; then
   for i in $(seq 0 "${testCount}"); do
     testType=$(yq eval ".tests[${i}].type" "${testPlan}")
-    echo "#### Running test: ${testType}"
-    helm test "${testType}" --namespace toolbox --logs
+    echo "#### Running test: ${testType} (timeout: ${helmTestTimeout})"
+    helm test "${testType}" --namespace toolbox --logs --timeout "${helmTestTimeout}"
   done
 fi


### PR DESCRIPTION
To make the k8s-monitoring helm chart openshift platform tests less flaky I want to be able to increase the timeout. Implemented via test definition by allowing extra args.

Also noticed that the openshift-installer cli prints the kubeadmin secret it creates when creating the cluster. While not a big deal because the cluster is temporary, it is still good to redact it (or anything else the cli prints)