### PR TITLE
feat: support additional `helm test` args

### DIFF
--- a/tools/helm-test/README.md
+++ b/tools/helm-test/README.md
@@ -110,7 +110,8 @@ FluxCD is always deployed to the cluster, because this helps managing deploying 
 This section defines the tests to be run after the Helm chart has been deployed. It is an array of objects, each with
 the following fields:
 
-| Field    | Description                                                | Required | Default |
-|----------|------------------------------------------------------------|----------|---------|
-| `type`   | The type of test to be run. Supported types: `query-test`. | Yes      |         |
-| `values` | The values to be used for the test as inline YAML.         | No       | `{}`    |
+| Field    | Description                                                                                   | Required | Default |
+|----------|-----------------------------------------------------------------------------------------------|----------|---------|
+| `type`   | The type of test to be run. Supported types: `query-test`.                                    | Yes      |         |
+| `values` | The values to be used for the test as inline YAML.                                             | No       | `{}`    |
+| `args`   | Additional arguments passed to `helm test`, for example `["--timeout", "10m"]`.               | No       | `[]`    |

--- a/tools/helm-test/README.md
+++ b/tools/helm-test/README.md
@@ -29,14 +29,6 @@ run-tests
 delete-cluster
 ```
 
-### Environment variables
-
-| Variable            | Description                                                | Default |
-|---------------------|------------------------------------------------------------|---------|
-| `CREATE_CLUSTER`    | Create the cluster before testing.                         | `true`  |
-| `DELETE_CLUSTER`    | Delete the cluster after testing.                          | `false` |
-| `HELM_TEST_TIMEOUT` | Timeout passed to `helm test` for each test (e.g. `15m`).  | `5m`    |
-
 ## Test Plans
 
 The `test-plan.yaml` file defines the test plan for the Helm chart. It includes the following sections:

--- a/tools/helm-test/README.md
+++ b/tools/helm-test/README.md
@@ -29,6 +29,14 @@ run-tests
 delete-cluster
 ```
 
+### Environment variables
+
+| Variable            | Description                                                | Default |
+|---------------------|------------------------------------------------------------|---------|
+| `CREATE_CLUSTER`    | Create the cluster before testing.                         | `true`  |
+| `DELETE_CLUSTER`    | Delete the cluster after testing.                          | `false` |
+| `HELM_TEST_TIMEOUT` | Timeout passed to `helm test` for each test (e.g. `15m`).  | `5m`    |
+
 ## Test Plans
 
 The `test-plan.yaml` file defines the test plan for the Helm chart. It includes the following sections:

--- a/tools/helm-test/TestPlan.md
+++ b/tools/helm-test/TestPlan.md
@@ -48,4 +48,6 @@
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | tests | list | `[]` | The list of test to be run after deploying the Helm chart test subject. Supported test types are: [query-test](https://github.com/grafana/helm-chart-toolbox/blob/main/charts/query-test) |
+| tests[].type | string | `""` | The type of the test to run. |
+| tests[].args | list | `[]` | Additional arguments to pass to the `helm test` command for this test, for example `["--timeout", "10m"]`. |
 <!-- textlint-enable terminology -->

--- a/tools/helm-test/includes/cluster/common.sh
+++ b/tools/helm-test/includes/cluster/common.sh
@@ -34,3 +34,10 @@ getRandomNumber() {
   fi
   echo "${randomNumber}"
 }
+
+redactSecrets() {
+  local keys='(password|passwd|pwd|token|secret|api[_-]?key|apikey|access[_-]?key|secret[_-]?key|client[_-]?secret|credential|bearer)'
+  sed -E \
+    -e "s/(${keys}[\"']?[[:space:]]*[:=][[:space:]]*)([\"'])[^\"']*\3/\1\3[REDACTED]\3/gI" \
+    -e "s/(${keys}[\"']?[[:space:]]*[:=][[:space:]]*)[^[:space:],;\"']+/\1[REDACTED]/gI"
+}

--- a/tools/helm-test/includes/cluster/openshift.sh
+++ b/tools/helm-test/includes/cluster/openshift.sh
@@ -26,7 +26,7 @@ createOpenShiftCluster() {
     fi
 
     echo "${createClusterCommand[@]}"
-    "${createClusterCommand[@]}"
+    "${createClusterCommand[@]}" 2>&1 | redactSecrets
 
   fi
   ln -sfn "${clusterInstallerFilesDir}/auth/kubeconfig" "${testDir}/kubeconfig.yaml"

--- a/tools/helm-test/run-tests
+++ b/tools/helm-test/run-tests
@@ -35,11 +35,12 @@ fi
 
 # Start of script
 echo; echo "### Running tests"
+helmTestTimeout="${HELM_TEST_TIMEOUT:-5m}"
 testCount=$(yq eval '.tests | length - 1' "${testPlan}")
 if [ "${testCount}" -ge 0 ]; then
   for i in $(seq 0 "${testCount}"); do
     testType=$(yq eval ".tests[${i}].type" "${testPlan}")
-    echo "#### Running test: ${testType}"
-    helm test "${testType}" --namespace toolbox --logs
+    echo "#### Running test: ${testType} (timeout: ${helmTestTimeout})"
+    helm test "${testType}" --namespace toolbox --logs --timeout "${helmTestTimeout}"
   done
 fi

--- a/tools/helm-test/run-tests
+++ b/tools/helm-test/run-tests
@@ -35,12 +35,18 @@ fi
 
 # Start of script
 echo; echo "### Running tests"
-helmTestTimeout="${HELM_TEST_TIMEOUT:-5m}"
 testCount=$(yq eval '.tests | length - 1' "${testPlan}")
 if [ "${testCount}" -ge 0 ]; then
   for i in $(seq 0 "${testCount}"); do
     testType=$(yq eval ".tests[${i}].type" "${testPlan}")
-    echo "#### Running test: ${testType} (timeout: ${helmTestTimeout})"
-    helm test "${testType}" --namespace toolbox --logs --timeout "${helmTestTimeout}"
+
+    # Read any additional helm test args defined for this test.
+    testArgs=()
+    while IFS= read -r arg; do
+      [ -n "${arg}" ] && testArgs+=("${arg}")
+    done < <(yq eval ".tests[${i}].args[]" "${testPlan}")
+
+    echo "#### Running test: ${testType}"
+    helm test "${testType}" --namespace toolbox --logs "${testArgs[@]}"
   done
 fi

--- a/tools/helm-test/tests/manifest-subject/test-plan.yaml
+++ b/tools/helm-test/tests/manifest-subject/test-plan.yaml
@@ -12,6 +12,9 @@ cluster:
 
 tests:
   - type: kubernetes-objects-test
+    args:
+      - --timeout
+      - 10m
     values:
       checks:
         - kind: Pod


### PR DESCRIPTION
To make the k8s-monitoring helm chart openshift platform tests less flaky I want to be able to increase the timeout. Implemented via test definition by allowing extra args.

Also noticed that the openshift-installer cli prints the kubeadmin secret it creates when creating the cluster. While not a big deal because the cluster is temporary, it is still good to redact it (or anything else the cli prints)

Based on https://github.com/grafana/helm-chart-toolbox/pull/126 since I messed up my local git branches